### PR TITLE
Check for returned object before accessing its 'count' property

### DIFF
--- a/endpoint.ts
+++ b/endpoint.ts
@@ -84,12 +84,14 @@ export default class Endpoint<T> extends IterableEndpoint<T> {
         super(service, endpoint);
     }
 
-    async count(options: FindOptions = {}): Promise<number> {
-        let url = '/Totals';
+    async count(options: {where?: string, include_deleted?: boolean} = {}): Promise<number> {
+        let url = '/totals';
         url += this.getEndpointURL();
-        url += '?select=count(InternalID) as count';
-        const query = Endpoint.encodeQueryParams(options);
-        url = query ? url + '&' + query : url;
+        const query = Endpoint.encodeQueryParams({
+            select: 'count(InternalID) as count',
+            ...options // rest operater flattens into the object
+        })
+        url = query ? url + '?' + query : url;
         const countObject = await this.service.get(url);
         return countObject[0].count;
     }

--- a/endpoint.ts
+++ b/endpoint.ts
@@ -84,6 +84,16 @@ export default class Endpoint<T> extends IterableEndpoint<T> {
         super(service, endpoint);
     }
 
+    async count(options: FindOptions = {}): Promise<number> {
+        let url = '/Totals';
+        url += this.getEndpointURL();
+        url += '?select=count(InternalID) as count';
+        const query = Endpoint.encodeQueryParams(options);
+        url = query ? url + '&' + query : url;
+        const countObject = await this.service.get(url);
+        return countObject[0].count;
+    }
+
     async get(id: number): Promise<T[]> {
         let url = this.getEndpointURL();
         url += '/' + id;

--- a/endpoint.ts
+++ b/endpoint.ts
@@ -93,7 +93,7 @@ export default class Endpoint<T> extends IterableEndpoint<T> {
         });
         url = query ? url + '?' + query : url;
         const countObject = await this.service.get(url);
-        return countObject[0].count;
+        return countObject && countObject.length == 1 ? countObject[0].count : 0;
     }
 
     async get(id: number): Promise<T[]> {

--- a/endpoint.ts
+++ b/endpoint.ts
@@ -84,13 +84,13 @@ export default class Endpoint<T> extends IterableEndpoint<T> {
         super(service, endpoint);
     }
 
-    async count(options: {where?: string, include_deleted?: boolean} = {}): Promise<number> {
+    async count(options: { where?: string; include_deleted?: boolean } = {}): Promise<number> {
         let url = '/totals';
         url += this.getEndpointURL();
         const query = Endpoint.encodeQueryParams({
             select: 'count(InternalID) as count',
-            ...options // rest operater flattens into the object
-        })
+            ...options,
+        });
         url = query ? url + '?' + query : url;
         const countObject = await this.service.get(url);
         return countObject[0].count;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pepperi-addons/papi-sdk",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pepperi-addons/papi-sdk",
-  "version": "1.21.6",
+  "version": "1.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pepperi-addons/papi-sdk",
-    "version": "1.21.6",
+    "version": "1.22.0",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pepperi-addons/papi-sdk",
-    "version": "1.22.1",
+    "version": "1.22.2",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
Workaround for papi not returning an object when where clause causes no objects to return.