### PR TITLE
Fix papi client performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pepperi-addons/papi-sdk",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pepperi-addons/papi-sdk",
-    "version": "1.24.0",
+    "version": "1.24.1",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/papi-performance.ts
+++ b/papi-performance.ts
@@ -41,9 +41,8 @@ const INITIAL_TIME = Date.now();
 export const crossPlatformPerformance: Performance = (() => {
     if (isNodeEnv()) {
         try {
-            const perfHooks = dynamicRequire(module, 'perf_hooks') as {
-                performance: Performance;
-            };
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const perfHooks = require('perf_hooks');
             return perfHooks.performance;
         } catch (e) {
             // return performanceFallback;


### PR DESCRIPTION
@alon-pepperi you broke the `performance` for node after rollup.
This fixes it.
