### PR TITLE
adding codeJobUUID for debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pepperi-addons/papi-sdk",
-    "version": "1.49.1",
+    "version": "1.49.2",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/papi-client.ts
+++ b/papi-client.ts
@@ -45,6 +45,7 @@ interface PapiClientOptions {
     suppressLogging?: boolean;
     addonSecretKey?: string;
     actionUUID?: string;
+    codeJobUUID?: string;
 }
 
 export class PapiClient {
@@ -137,6 +138,10 @@ export class PapiClient {
 
         if (this.options.actionUUID) {
             options.headers['X-Pepperi-ActionID'] = this.options.actionUUID;
+        }
+
+        if (this.options.codeJobUUID) {
+            options.headers['X-Pepperi-CodeJobID'] = this.options.codeJobUUID;
         }
         const performance = getPerformance();
         const t0 = performance?.now();


### PR DESCRIPTION
this is basic so I will be able to pass along the codeJobUUD from lambda to Lambda 
note, if the operation will be async and there is no code job UUID the actionUUID will become the codejobUUID